### PR TITLE
feat(event-switch): add a graceful stop to the EventSwitch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: go
 go:
-  - 1.8.x
-  - 1.9.x
-  - 1.10.x
   - 1.11.x
+  - 1.12.x
+  - 1.13.x
   - master
 
 before_install:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SHELL := $(shell which bash) # set default shell
+SHELL := $(shell which bash)
 GOFMT ?= gofmt "-s"
 PACKAGES ?= $(shell go list ./... | grep -v /vendor/)
 GOFILES := $(shell find . -name "*.go" -type f -not -path "./vendor/*")
@@ -19,9 +19,9 @@ help: ## Show Help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 dep: ## Get build dependencies
-	go get -v -u github.com/golang/dep/cmd/dep; \
 	go get github.com/mitchellh/gox; \
-	go get github.com/mattn/goveralls; 
+	go get github.com/mattn/goveralls; \
+	curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 
 lint: ## lint the code
 	@hash golint > /dev/null 2>&1; if [ $$? -ne 0 ]; then \

--- a/event.go
+++ b/event.go
@@ -5,31 +5,27 @@ import (
 	"fmt"
 	"log"
 	"sync"
+	"time"
 )
 
-// EventState will give the status of an event throu the application
 type EventState int
 
 const (
-	// ESEmitted means he is currently being processed amongst switch, interceptor and receiver
+	// ESEmitted the event is being processed
 	ESEmitted EventState = iota
-	// ESResolved means every interceptor and receiver have finished their job on this event
+	// ESResolved the event has been successfully processed by the interceptors and the receivers
 	ESResolved
-	// ESAborted can be set by an interceptor, it will stop event processing
+	// ESAborted the event processing is stopped which means that it won't be transmitted to any receiver
 	ESAborted
-	// ESError means there is 1 or more failure during treatment
+	// ESError the event encountered an error during its processing
 	ESError
 )
 
-// Event an Event can be transmitted from an Emitter to any Receiver
-//
-// they're not yet immutable but needs to be considered as they can be concucrrently accessed
-//
-// The id is set internally and can be override only if another generator is used.
-//
-// metadatas can be set through the AddMetadata(key string, value interface{}) and retrieve throu GetMetadata(key string)
-//
-// an event is locked after "interceptor" phase. it means his metadata cannot be modified throu previous methods
+// Event an Event can be transmitted from an Emitter to any Receiver.
+// It's not yet immutable but needs to be considered as they can be concurrently accessed.
+// The id is set internally and can be overridden only if another generator is used.
+// The metadata can be set with AddMetadata(key string, value interface{}) and can be retrieved with GetMetadata(key string).
+// An event is locked after "interceptor" phase which means its metadata cannot be modified through previous methods.
 //
 type Event struct {
 	Type     string
@@ -41,7 +37,7 @@ type eventMetadata struct {
 	id             uint64
 	state          EventState
 	datas          map[string]interface{}
-	lock           bool
+	locked         bool
 	states         map[string]EventState
 	mu             *sync.Mutex
 	totalListeners int
@@ -49,16 +45,15 @@ type eventMetadata struct {
 	abortReason    string
 }
 
-// GetID Retrieve the id of an event
 func (event *Event) GetID() uint64 {
 	return event.metadata.id
 }
 
-// Abort can be used to abort event dispatching after the current interceptor
-//
-// a locked event cannot be aborted
+// Abort stop the processing of the event.
+// This method could be called from any interceptor.
+// A locked event cannot be aborted.
 func (event *Event) Abort(current EventInterceptor, reason string) {
-	if event.metadata.lock {
+	if event.metadata.locked {
 		return
 	}
 	event.setState(current.Key(), ESAborted)
@@ -71,31 +66,29 @@ func (event *Event) setID(id uint64) {
 
 // AddMetadata add a key value pair of metadata to the event
 //
-// an error will occur if the event is locked or if the key is already set
+// An error will occur if the event is locked or if the key exists already.
 func (event *Event) AddMetadata(key string, value interface{}) error {
-	if event.metadata.lock {
-		return newError(fmt.Errorf("event id %v already lock", event.metadata.id)).SetErrType(ErrTypeEvent)
+	if event.metadata.locked {
+		return newError(fmt.Errorf("event id %v already locked", event.metadata.id)).SetErrType(ErrTypeEvent)
 	}
 	if _, ok := event.metadata.datas[key]; ok {
-		return newError(fmt.Errorf("unable to set metadata key %s. already setted", key)).SetErrType(ErrTypeEvent)
+		return newError(fmt.Errorf("the key '%s' already exists", key)).SetErrType(ErrTypeEvent)
 	}
 	event.metadata.datas[key] = value
 	return nil
 }
 
-// GetMetadata retrieve a metadata
 func (event *Event) GetMetadata(key string) interface{} {
 	return event.metadata.datas[key]
 }
 
-// GetState return the current state
 func (event *Event) GetState() EventState {
 	return event.metadata.state
 }
 
-// GetStates return a copy of current states
+// GetStates return a copy of the current states.
 //
-// can be accessed by multiple go routine
+// This method is thread-safe.
 func (e eventMetadata) GetStates() map[string]EventState {
 	e.mu.Lock()
 	states := make(map[string]EventState)
@@ -106,42 +99,38 @@ func (e eventMetadata) GetStates() map[string]EventState {
 	return states
 }
 
-func (event *Event) setStateIf(key string, ifstate, state EventState) {
-	e := event.metadata
-	e.mu.Lock()
-	if e.states[key] == ifstate {
-		e.mu.Unlock()
-		event.setState(key, state)
+func (event *Event) setStateIf(key string, expectedState, newState EventState) {
+	event.metadata.mu.Lock()
+	if event.metadata.states[key] == expectedState {
+		event.metadata.mu.Unlock()
+		event.setState(key, newState)
 	} else {
-		e.mu.Unlock()
+		event.metadata.mu.Unlock()
 	}
 }
 
-func (event *Event) setState(key string, state EventState) {
+func (event *Event) setState(key string, newState EventState) {
 	event.metadata.mu.Lock()
-	event.metadata.states[key] = state
-	nberr := 0
-	nbres := 0
-	nbemit := 0
-	for _, s := range event.metadata.states {
-		switch s {
-		case ESAborted:
-			event.metadata.state = ESAborted
-			event.metadata.mu.Unlock()
-			event.runFinalizer()
-			return
-		case ESEmitted:
-			nbemit = nbemit + 1
-			// we can stop verifying states as we still have something running
-			break
-		case ESResolved:
-			nbres = nbres + 1
-		case ESError:
-			nberr = nberr + 1
-		}
+
+	if newState == ESAborted {
+		event.metadata.state = ESAborted
+		event.metadata.mu.Unlock()
+		event.runFinalizer()
+		return
 	}
-	if nbemit == 0 && event.metadata.totalListeners == nberr+nbres {
-		if nberr > 0 {
+
+	event.metadata.states[key] = newState
+
+	lessStateThanExpected := len(event.metadata.states) < event.metadata.totalListeners
+	notYetResolved := newState == ESEmitted
+	if lessStateThanExpected || notYetResolved {
+		event.metadata.mu.Unlock()
+		return
+	}
+
+	resolvedCount, errorCount := countResolvedAndErrorStates(event)
+	if event.metadata.totalListeners == errorCount+resolvedCount {
+		if errorCount > 0 {
 			event.metadata.state = ESError
 		} else {
 			event.metadata.state = ESResolved
@@ -150,16 +139,27 @@ func (event *Event) setState(key string, state EventState) {
 		event.runFinalizer()
 		return
 	}
+
 	event.metadata.mu.Unlock()
 }
 
-// Emitter The base interface of an emitter
+func countResolvedAndErrorStates(event *Event) (resolvedCount, errorCount int) {
+	for _, s := range event.metadata.states {
+		switch s {
+		case ESResolved:
+			resolvedCount += 1
+		case ESError:
+			errorCount += 1
+		}
+	}
+	return
+}
+
 type Emitter interface {
 	prepareRun(chan *Event, IDGenerator, map[string]int, EventFinalizer)
 	Emit(*Event)
 }
 
-// EventEmitter event emitter
 type EventEmitter struct {
 	idGenerator    IDGenerator
 	eventChan      chan *Event
@@ -174,7 +174,7 @@ func (ee *EventEmitter) prepareRun(e chan *Event, idGen IDGenerator, lc map[stri
 	ee.finalizer = f
 }
 
-// Emit emits an event
+// Emit adds metadata to the event then emit it through the channel
 func (ee *EventEmitter) Emit(event *Event) {
 	event.metadata.id = ee.idGenerator.NextID()
 	event.metadata.state = ESEmitted
@@ -186,38 +186,28 @@ func (ee *EventEmitter) Emit(event *Event) {
 	ee.eventChan <- event
 }
 
-// EventReceiver event receiver is like observer,
-//
-// all receiveEvent are received in a choregraphic pattern, asynchronously
-//
-// the HandleEventType filter the events this Receiver wants to receive
+// EventReceiver
+// All events are treated in a choreographic pattern, asynchronously.
+// The HandleEventTypes should return the types of event the receiver wants to handle.
 type EventReceiver interface {
 	Identifier
 	ReceiveEvent(*Event) error
 	HandleEventTypes() []string
 }
 
-// EventInterceptor interceptor interface
-//
-// an Interceptor
-//
-// - will see all event goes throu intercept method
-//
-// - can call Abort on an Event
-//
-// - has a priority : there can't be 2 interceptors at the same priority
+// EventInterceptor any events handled by the EventSwitch goes through the interceptors.
+// An interceptor can abort an Event to stop its processing beyond the interceptor itself.
+// An interceptor must define a priority and 2 interceptors cannot have the same priority.
 type EventInterceptor interface {
 	Identifier
 	Intercept(*Event) error
 	InterceptPriority() int
 }
 
-// EventFinalizer event finalizer can be declared
 type EventFinalizer interface {
 	Finalize(*Event)
 }
 
-// IDGenerator handle id generation
 type IDGenerator interface {
 	SetSeed(uint64) error
 	NextID() uint64
@@ -256,32 +246,34 @@ func newGenerator() IDGenerator {
 
 // EventSwitch this is not a hub, we want a switch
 type EventSwitch struct {
-	mainChain        chan *Event
-	close            chan struct{}
-	emitters         []Emitter
-	receivers        map[string][]EventReceiver
-	interceptors     map[int]EventInterceptor
-	listenerCount    map[string]int
-	orderedIntercept []int
-	running          bool
-	hasInterceptor   bool
-	idGenerator      IDGenerator
-	eventFinalizer   EventFinalizer
+	mainChan            chan *Event
+	close               chan struct{}
+	emitters            []Emitter
+	receivers           map[string][]EventReceiver
+	interceptors        map[int]EventInterceptor
+	listenerCount       map[string]int
+	orderedIntercept    []int
+	running             bool
+	hasInterceptor      bool
+	idGenerator         IDGenerator
+	eventFinalizer      EventFinalizer
+	pendingEventCounter Counter
 }
 
 // NewEventSwitch build a new event switch
 func NewEventSwitch(bufferSize int) *EventSwitch {
 	return &EventSwitch{
-		mainChain:        make(chan *Event, bufferSize),
-		close:            make(chan struct{}),
-		receivers:        make(map[string][]EventReceiver),
-		interceptors:     make(map[int]EventInterceptor),
-		listenerCount:    make(map[string]int),
-		orderedIntercept: nil,
-		running:          false,
-		hasInterceptor:   true,
-		idGenerator:      newGenerator(),
-		eventFinalizer:   nil,
+		mainChan:            make(chan *Event, bufferSize),
+		close:               make(chan struct{}),
+		receivers:           make(map[string][]EventReceiver),
+		interceptors:        make(map[int]EventInterceptor),
+		listenerCount:       make(map[string]int),
+		orderedIntercept:    nil,
+		running:             false,
+		hasInterceptor:      true,
+		idGenerator:         newGenerator(),
+		eventFinalizer:      nil,
+		pendingEventCounter: newCounter(),
 	}
 }
 
@@ -322,7 +314,7 @@ func (es *EventSwitch) WithEventFinalizer(f EventFinalizer) *EventSwitch {
 // AddEmitter add an emitter
 func (es *EventSwitch) AddEmitter(e Emitter) error {
 	if es.running {
-		return newError(errors.New("Can't add an emitter on the fly yet")).SetErrType(ErrTypeEvent)
+		return newError(errors.New("can't add an emitter on the fly yet")).SetErrType(ErrTypeEvent)
 	}
 	es.emitters = append(es.emitters, e)
 	return nil
@@ -331,7 +323,7 @@ func (es *EventSwitch) AddEmitter(e Emitter) error {
 // AddReceiver add a receiver
 func (es *EventSwitch) AddReceiver(e EventReceiver) error {
 	if es.running {
-		return newError(errors.New("Can't add a receiver on the fly yet")).SetErrType(ErrTypeEvent)
+		return newError(errors.New("can't add a receiver on the fly yet")).SetErrType(ErrTypeEvent)
 	}
 	for _, et := range e.HandleEventTypes() {
 		es.receivers[et] = append(es.receivers[et], e)
@@ -339,10 +331,11 @@ func (es *EventSwitch) AddReceiver(e EventReceiver) error {
 	return nil
 }
 
-// AddInterceptor add an interceptor. Interceptor must be prioritized through InterceptPriority(), only one interceptor can run at the same priority
+// AddInterceptor add an interceptor.
+// An error is returned when an interceptor with the same priority is already declared.
 func (es *EventSwitch) AddInterceptor(e EventInterceptor) error {
 	if es.running {
-		return newError(errors.New("Can't add an interceptor on the fly")).SetErrType(ErrTypeEvent)
+		return newError(errors.New("can't add an interceptor on the fly")).SetErrType(ErrTypeEvent)
 	}
 	if _, ok := es.interceptors[e.InterceptPriority()]; ok {
 		return newError(fmt.Errorf("another interceptor already declared on priority %v", e.InterceptPriority())).SetErrType(ErrTypeEvent)
@@ -352,7 +345,7 @@ func (es *EventSwitch) AddInterceptor(e EventInterceptor) error {
 	return nil
 }
 
-// Start will start the event switch
+// Start initialize the EventSwitch and start it
 func (es *EventSwitch) Start() {
 	if es.running {
 		return
@@ -369,39 +362,60 @@ func (es *EventSwitch) Start() {
 		es.listenerCount[k] = nbInterceptor + len(v)
 	}
 	for _, e := range es.emitters {
-		e.prepareRun(es.mainChain, es.idGenerator, es.listenerCount, es.eventFinalizer)
+		e.prepareRun(es.mainChan, es.idGenerator, es.listenerCount, es.eventFinalizer)
 	}
 	es.running = true
 	go es.run()
 }
 
-// Stop will stop the event switch.
 func (es *EventSwitch) Stop() {
-	if !es.running {
-		return
+	if es.running {
+		es.close <- struct{}{}
+		es.running = false
 	}
-	es.close <- struct{}{}
-	es.running = false
 }
 
-// Close close all chan
+// Close stop the EventEmitter then closes it channels
 func (es *EventSwitch) Close() {
 	es.Stop()
 	close(es.close)
-	close(es.mainChain)
+	close(es.mainChan)
+}
+
+// CloseGracefully wait for all events to be processed then close the EventSwitch
+// This method is blocking until the EventSwitch is stopped.
+func (es *EventSwitch) CloseGracefully() {
+	if es.running {
+		go es.closeOnceAllEventsAreHandled()
+		for es.running {
+			// Should stop running once all events are processed
+		}
+	}
+}
+
+func (es *EventSwitch) closeOnceAllEventsAreHandled() {
+	for es.hasUnreadEvent() || es.hasPendingEvent() {
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	es.Close()
+}
+
+func (es *EventSwitch) hasUnreadEvent() bool {
+	return len(es.mainChan) != 0
+}
+
+func (es *EventSwitch) hasPendingEvent() bool {
+	return es.pendingEventCounter.count != 0
 }
 
 func (es *EventSwitch) run() {
 	for {
 		select {
-		case event, valid := <-es.mainChain:
-			if !es.running {
-				break
+		case event, valid := <-es.mainChan:
+			if es.running && valid {
+				go es.switchEvent(event)
 			}
-			if !valid {
-				break
-			}
-			go es.switchEvent(event)
 		case <-es.close:
 			return
 		}
@@ -409,57 +423,74 @@ func (es *EventSwitch) run() {
 }
 
 func (es *EventSwitch) switchEvent(event *Event) {
+	es.pendingEventCounter.increase()
+	defer es.pendingEventCounter.decrease()
+
+	aborted := es.runInterceptorsIfAny(event)
+	if aborted {
+		return
+	}
+
+	event.metadata.locked = true
+	es.runReceivers(event)
+}
+
+func (es *EventSwitch) runInterceptorsIfAny(event *Event) bool {
 	if es.hasInterceptor {
-		for _, prio := range es.orderedIntercept {
-			interceptor := es.interceptors[prio]
+		for _, priority := range es.orderedIntercept {
+			interceptor := es.interceptors[priority]
 			es.runInterceptorWithRecover(interceptor, event)
+
 			if event.metadata.state == ESAborted {
 				log.Printf("[Godim EventSwitch] aborting event id [%v]\n", event.metadata.id)
-				return
+				return true
 			}
 		}
 	}
-	event.metadata.lock = true
-	rs, ok := es.receivers[event.Type]
-	if ok {
-		for _, receiver := range rs {
-			go es.runObserverWithRecover(receiver, event)
-		}
-	}
-}
-
-func (es *EventSwitch) runObserverWithRecover(receiver EventReceiver, event *Event) {
-	event.setState(receiver.Key(), ESEmitted)
-	defer internalRecover(event, receiver)
-	err := receiver.ReceiveEvent(event)
-	if err != nil {
-		event.setState(receiver.Key(), ESError)
-	}
+	return false
 }
 
 func (es *EventSwitch) runInterceptorWithRecover(interceptor EventInterceptor, event *Event) {
 	event.setState(interceptor.Key(), ESEmitted)
+
 	defer internalRecover(event, interceptor)
+
 	err := interceptor.Intercept(event)
 	if err != nil {
 		event.setState(interceptor.Key(), ESError)
 	}
 }
 
+func (es *EventSwitch) runReceivers(event *Event) {
+	rs, ok := es.receivers[event.Type]
+	if ok {
+		for _, receiver := range rs {
+			go es.runReceiverWithRecover(receiver, event)
+		}
+	}
+}
+
+func (es *EventSwitch) runReceiverWithRecover(receiver EventReceiver, event *Event) {
+	event.setState(receiver.Key(), ESEmitted)
+
+	defer internalRecover(event, receiver)
+
+	err := receiver.ReceiveEvent(event)
+	if err != nil {
+		event.setState(receiver.Key(), ESError)
+	}
+}
+
 func internalRecover(event *Event, identifier Identifier) {
 	if rec := recover(); rec != nil {
 		event.setState(identifier.Key(), ESError)
-		dumpRec(rec, "godim: panic receiving event")
+		logCaughtPanic(rec, "[Godim EventSwitch] panic receiving event")
 	} else {
 		event.setStateIf(identifier.Key(), ESEmitted, ESResolved)
 	}
 }
 
-func dumpRec(rec interface{}, msg string) {
-	// const size = 64 << 10
-	// buffer := make([]byte, size)
-	// buffer = buffer[:runtime.Stack(buffer, false)]
-	// log.Printf("%s: %v\n%s", msg, rec, buffer)
+func logCaughtPanic(rec interface{}, msg string) {
 	log.Printf("%s: %v\n", msg, rec)
 }
 
@@ -467,9 +498,32 @@ func (event *Event) runFinalizer() {
 	if event.metadata.finalizer != nil {
 		defer func() {
 			if rec := recover(); rec != nil {
-				dumpRec(rec, "godim: panic finalizing event")
+				logCaughtPanic(rec, "[Godim EventSwitch] panic finalizing event")
 			}
 		}()
 		event.metadata.finalizer.Finalize(event)
 	}
+}
+
+type Counter struct {
+	count uint
+	mutex *sync.Mutex
+}
+
+func newCounter() Counter {
+	return Counter{
+		mutex: new(sync.Mutex),
+	}
+}
+
+func (ec *Counter) increase() {
+	ec.mutex.Lock()
+	ec.count += 1
+	ec.mutex.Unlock()
+}
+
+func (ec *Counter) decrease() {
+	ec.mutex.Lock()
+	ec.count -= 1
+	ec.mutex.Unlock()
 }

--- a/godim.go
+++ b/godim.go
@@ -17,7 +17,7 @@ type Godim struct {
 	eventSwitch    *EventSwitch
 }
 
-// Default build a default godim from default configuration
+// Default build a default Godim from default configuration
 func Default() *Godim {
 	return DefaultConfig().Build()
 }
@@ -134,16 +134,33 @@ func (godim *Godim) RunApp() error {
 
 // CloseApp close all things declared in your app
 func (godim *Godim) CloseApp() error {
+	if err := godim.closeIfRunning(); err != nil {
+		return err
+	}
+
+	if godim.eventSwitch != nil {
+		godim.eventSwitch.Close()
+	}
+
+	return nil
+}
+
+// CloseApp close all things declared in your app
+func (godim *Godim) CloseAppGracefully() error {
+	if godim.eventSwitch != nil {
+		godim.eventSwitch.CloseGracefully()
+	}
+
+	return godim.closeIfRunning()
+}
+
+func (godim *Godim) closeIfRunning() error {
 	if godim.lifecycle.current(stRun) {
 		err := godim.registry.closeAll()
 		if err != nil {
 			return err
 		}
 		godim.lifecycle.currentState++
-	}
-	// Closing event switch if enable
-	if godim.eventSwitch != nil {
-		godim.eventSwitch.Close()
 	}
 	return nil
 }


### PR DESCRIPTION
It allows the EventSwitch to be closed only after all events have been read then received by all the receivers.

The `setState` method has been improved. The loop over all the states is now skipped if the new state is either Aborted or Emitted.

I've also:
- cleaned up the code
- improved documentation
- fixed the test for massive events (it was only using 1 receiver instead of 10)
