### PR TITLE
<fix>(PROFILE): Fix custom profile creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor/*
 profile.out
 acc.out
 coverage.out
+.idea

--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ package main
 import (
   "github.com/ekino/godim"
   "fmt"
+  "log"
 )
 
 type MyHandler struct {
-  UserService *UserService `inject:"UserService"`
+  UserService *UserService `inject:"default:UserService"`
 }
 
 func (mh *MyHandler) doIt() {
@@ -47,7 +48,14 @@ func config(key string, kind reflect.Kind) (interface{}, error) {
 func main(){
   mh := MyHandler{}
   us := UserService{}
-  g := godim.NewGodim(godim.DefaultConfig().WithConfigurationFunction())
+  
+  profile :=  godim.NewAppProfile()
+  // Manually declare default profile (auto initialization seems broken)
+  if err := profile.AddProfile(&godim.DefaultProfile); err != nil {
+  	 log.Panic(err)
+   }
+
+  g := godim.NewGodim(godim.DefaultConfig().WithConfigurationFunction(config))
   g.DeclareDefault(&mh,&us)
   g.RunApp()
   
@@ -81,7 +89,7 @@ type UserService struct {
 
 }
 ````
-will have a name : main.UserService
+will have a name : profileName:UserService where profileName is the name of the profile the structure is declared in 
 
 #### Profile
 

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ func DefaultConfig() *Config {
 	return &Config{
 		injectString: defaultInject,
 		configString: defaultConfig,
-		appProfile:   newAppProfile(),
+		appProfile:   NewAppProfile(),
 		activateES:   false,
 	}
 }
@@ -86,7 +86,7 @@ func (c *Config) WithEventSwitch(bufferSize int) *Config {
 // Build lock profile and build godim
 func (c *Config) Build() *Godim {
 	if c.appProfile == nil {
-		c.appProfile = newAppProfile()
+		c.appProfile = NewAppProfile()
 	}
 	c.appProfile.lock()
 	if c.activateES {

--- a/profile.go
+++ b/profile.go
@@ -41,7 +41,7 @@ var DefaultProfile = Profile{
 
 // NewAppProfile returns a new AppProfile that will drive
 // injection and dependency throu your application
-func newAppProfile() *AppProfile {
+func NewAppProfile() *AppProfile {
 	return &AppProfile{
 		profiles: make(map[string]*Profile),
 		locked:   false,
@@ -59,7 +59,7 @@ func newAppProfile() *AppProfile {
 // - driver : manage resource driver
 //
 func StrictHTTPAppProfile() *AppProfile {
-	app := newAppProfile()
+	app := NewAppProfile()
 	app.AddProfileDef("handler")
 	app.AddProfileDef("service", "handler")
 	app.AddProfileDef("repository", "service")
@@ -77,7 +77,7 @@ func StrictHTTPAppProfile() *AppProfile {
 // - repository : manage data access
 //
 func HTTPAppProfile() *AppProfile {
-	app := newAppProfile()
+	app := NewAppProfile()
 	app.AddProfileDef("handler")
 	app.AddProfileDef("service", "handler", "service")
 	app.AddProfileDef("repository", "service")
@@ -121,6 +121,9 @@ func (ap *AppProfile) AddProfileDef(name string, injectIn ...string) error {
 func (ap *AppProfile) AddProfile(p *Profile) error {
 	if ap.locked {
 		return newError(fmt.Errorf("AppProfile locked, can't add new profile")).SetErrType(ErrTypeProfile)
+	}
+	if ap.profiles == nil {
+		ap.profiles = map[string]*Profile{}
 	}
 	if ap.profiles[p.name] != nil {
 		return newError(fmt.Errorf("%s is already declared", p.name)).SetErrType(ErrTypeProfile)

--- a/registry.go
+++ b/registry.go
@@ -45,7 +45,7 @@ func newRegistry() *Registry {
 	return &Registry{
 		inject:     defaultInject,
 		config:     defaultConfig,
-		appProfile: newAppProfile(),
+		appProfile: NewAppProfile(),
 		values:     make(map[string]map[string]*holder),
 		tags:       make(map[reflect.Type]*TagConfig),
 		inits:      make(map[int]map[reflect.Type]reflect.Value),


### PR DESCRIPTION
- Make NewAppProfile method public (looks more coherent to me as the item is public and others public method does not work when init is not done)
- Check if profile map is initialized before adding element in it. If not, initialize it on the fly